### PR TITLE
Update jQuery selector to fit 25.05 HTML structure

### DIFF
--- a/Koha/Plugin/Com/ByWaterSolutions/ItemMessages/static_files/intranet.js
+++ b/Koha/Plugin/Com/ByWaterSolutions/ItemMessages/static_files/intranet.js
@@ -40,10 +40,10 @@ $(document).ready(function() {
                 });
 
                 $(`
-				<div class="rows">
+				<div class="listgroup">
 					<div id="item-messages-${itemnumber}" class="item-messages"></div>
 				</div>
-			`).insertAfter( $(this).siblings('.rows') );
+			`).appendTo( $(this).siblings('.page-section') );
 
                 ReactDOM.render(
                     html `<${ItemMessages} itemnumber=${itemnumber} messages=${messages} />`,


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the jQuery insertion target to match the 25.05 HTML structure by replacing the wrapper div class from "rows" to "listgroup" and changing the insertion point from after the ".rows" sibling to appending into the ".page-section" sibling.

### Why are these changes being made?

To align with the updated 25.05 DOM structure and ensure the item messages UI renders in the correct location.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->